### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A Model Context Protocol (MCP) server implementation that provides Google News search capabilities via SerpAPI integration. Automatically categorizes news results and supports multiple languages and regions.
 
+<a href="https://glama.ai/mcp/servers/dbx6imq4ef"><img width="380" height="200" src="https://glama.ai/mcp/servers/dbx6imq4ef/badge" alt="Google News Server MCP server" /></a>
+
 English | [简体中文](./README_CN.md)
 
 https://github.com/user-attachments/assets/1cc71c27-f840-4c94-9ab5-460d84ba4779


### PR DESCRIPTION
This PR adds a badge for the Google News MCP Server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dbx6imq4ef"><img width="380" height="200" src="https://glama.ai/mcp/servers/dbx6imq4ef/badge" alt="Google News Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.